### PR TITLE
Update secure_stager.py

### DIFF
--- a/secure_stager.py
+++ b/secure_stager.py
@@ -5,6 +5,7 @@ import os
 import hashlib
 import subprocess
 from urllib.parse import urlparse
+import shutil
 
 def xor(binary_blob, key):
     # Convert the key to bytes
@@ -57,7 +58,7 @@ enc_stage = f"{outdir}{url.path}"
 stager = f"{outdir}{url.path}_stager.bin"
 
 # Rename original raw payload
-os.rename(sys.argv[1], original_stage)
+shutil.move(sys.argv[1], original_stage)
 
 # Calculate MD5 hash of raw payload
 stage_md5 = hashlib.md5(stage).hexdigest()
@@ -85,7 +86,7 @@ while True:
         pass
 
 # Rename stager
-os.rename("Stardust/bin/stardust.x64.bin", stager)
+shutil.move("Stardust/bin/stardust.x64.bin", stager)
 
 # Print info
 print("[SECURE STAGER]")


### PR DESCRIPTION
changed `os.rename` to `shutil.move` (removes error `OSError: [Errno 18] Invalid cross-device link`)

Error I had:
```
Traceback (most recent call last):
  File "/home/kali/Secure_Stager/secure_stager.py", line 88, in <module>
    os.rename("Stardust/bin/stardust.x64.bin", stager)
OSError: [Errno 18] Invalid cross-device link: 'Stardust/bin/stardust.x64.bin' -> '/tmp/aboutme_stager.bin'
```

Solution: [Stackoverflow]( https://stackoverflow.com/questions/42392600/oserror-errno-18-invalid-cross-device-link)